### PR TITLE
Feature: Semantic validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ It shows how to integrate ANTLR with monaco.
 
 ![Calc Example](./doc/images/calc_example.png)
 
+## Features
+
+* Text editing provided by [monaco](https://github.com/microsoft/monaco-editor)
+* Syntax highlighting for custom language
+* Syntax error reporting with expected alternatives
+* Semantic error reporting for undeclared and redeclared variables
+
 ## Generating the lexer and the parser
 
 ```

--- a/src/main/typescript/ParserFacade.ts
+++ b/src/main/typescript/ParserFacade.ts
@@ -168,6 +168,8 @@ export function validate(input) : Error[] {
 
         const outputIdentifier = output.ID().symbol;
 
+        if (outputIdentifier.text === "<missing null>") continue;
+
         if (!scope.some(x => x === outputIdentifier.text)) {
             errors.push(createErrorAt(outputIdentifier, "undeclared symbol"));
         }

--- a/src/main/typescript/ParserFacade.ts
+++ b/src/main/typescript/ParserFacade.ts
@@ -142,6 +142,8 @@ export function validate(input) : Error[] {
 
     for (const input of tree.inputs) {
 
+        if (input.ID() === null) continue;
+
         const inputIdentifier = input.ID().symbol;
 
         if (scope.some(x => x === inputIdentifier.text)) {
@@ -162,6 +164,8 @@ export function validate(input) : Error[] {
 
     for (const output of tree.outputs) {
 
+        if (output.ID() === null) continue;
+
         const outputIdentifier = output.ID().symbol;
 
         if (!scope.some(x => x === outputIdentifier.text)) {
@@ -170,6 +174,8 @@ export function validate(input) : Error[] {
     }
 
     function validateExpression(expression) {
+        if (expression === null || expression.children === null) return;
+
         for (const child of expression.children) {
             if (child.children) {
                 validateExpression(child);

--- a/src/main/typescript/ParserFacade.ts
+++ b/src/main/typescript/ParserFacade.ts
@@ -137,5 +137,24 @@ export function validate(input) : Error[] {
     parser._errHandler = new CalcErrorStrategy();
 
     const tree = parser.compilationUnit();
+
+    const scope = [];
+
+    for (const input of tree.inputs) {
+
+        const inputIdentifier = input.ID().symbol;
+
+        if (scope.some(x => x === inputIdentifier.text)) {
+            errors.push(createErrorAt(inputIdentifier, "input already declared"));
+        }
+        else {
+            scope.push(inputIdentifier.text);
+        }
+    }
+
     return errors;
+}
+
+function createErrorAt(node, message) {
+    return new Error(node.line, node.line, node.column + 1, node.column + node.stop - node.start + 2, message);
 }

--- a/src/main/typescript/ParserFacade.ts
+++ b/src/main/typescript/ParserFacade.ts
@@ -160,6 +160,15 @@ export function validate(input) : Error[] {
         }
     }
 
+    for (const output of tree.outputs) {
+
+        const outputIdentifier = output.ID().symbol;
+
+        if (!scope.some(x => x === outputIdentifier.text)) {
+            errors.push(createErrorAt(outputIdentifier, "undeclared symbol"));
+        }
+    }
+
     function validateExpression(expression) {
         for (const child of expression.children) {
             if (child.children) {

--- a/src/test/javascript/parsingTest.js
+++ b/src/test/javascript/parsingTest.js
@@ -64,12 +64,12 @@ describe('Basic parsing of simple script', function () {
 
 describe('Validation of simple errors on single lines', function () {
     describe('should have recognize missing operand', function () {
-        parseAndCheckErrors("o = i + \n", [
+        parseAndCheckErrors("o = 1 + \n", [
             new parserFacade.Error(1, 1, 8, 9, "mismatched input '\\n' expecting {NUMBER_LIT, ID, '(', '-'}")
         ]);
     });
     describe('should have recognize extra operator', function () {
-        parseAndCheckErrors("o = i +* 2 \n", [
+        parseAndCheckErrors("o = 1 +* 2 \n", [
             new parserFacade.Error(1, 1, 7, 8, "extraneous input '*' expecting {NUMBER_LIT, ID, '(', '-'}")
         ]);
     });
@@ -144,6 +144,18 @@ describe('Semantic validation', function () {
         parseAndCheckErrors(input, [
             new parserFacade.Error(2, 2, 7, 8, "input already declared"),
             new parserFacade.Error(3, 3, 7, 8, "input already declared")
+        ]);
+    });
+    describe('should report undeclared symbol', function () {
+        let input = "o = i\n";
+        parseAndCheckErrors(input, [
+            new parserFacade.Error(1, 1, 5, 6, "undeclared symbol")
+        ]);
+    });
+    describe('should report undeclared symbol in line 4', function () {
+        let input = "input i\no = i\no = o\no = u\n";
+        parseAndCheckErrors(input, [
+            new parserFacade.Error(4, 4, 5, 6, "undeclared symbol")
         ]);
     });
 });

--- a/src/test/javascript/parsingTest.js
+++ b/src/test/javascript/parsingTest.js
@@ -158,4 +158,16 @@ describe('Semantic validation', function () {
             new parserFacade.Error(4, 4, 5, 6, "undeclared symbol")
         ]);
     });
+    describe('should report undeclared symbol for output', function () {
+        let input = "output o\n";
+        parseAndCheckErrors(input, [
+            new parserFacade.Error(1, 1, 8, 9, "undeclared symbol")
+        ]);
+    });
+    describe('should report undeclared symbol for second output', function () {
+        let input = "input i\no = i\noutput o\noutput x\n";
+        parseAndCheckErrors(input, [
+            new parserFacade.Error(4, 4, 8, 9, "undeclared symbol")
+        ]);
+    });
 });

--- a/src/test/javascript/parsingTest.js
+++ b/src/test/javascript/parsingTest.js
@@ -131,3 +131,19 @@ describe('Unrecognized tokens cause errors', function () {
         ]);
     });
 });
+
+describe('Semantic validation', function () {
+    describe('should report input already declared', function () {
+        let input = "input i\ninput i\n";
+        parseAndCheckErrors(input, [
+            new parserFacade.Error(2, 2, 7, 8, "input already declared")
+        ]);
+    });
+    describe('should report input already declared twice', function () {
+        let input = "input i\ninput i\ninput i\n";
+        parseAndCheckErrors(input, [
+            new parserFacade.Error(2, 2, 7, 8, "input already declared"),
+            new parserFacade.Error(3, 3, 7, 8, "input already declared")
+        ]);
+    });
+});

--- a/src/test/javascript/parsingTest.js
+++ b/src/test/javascript/parsingTest.js
@@ -171,3 +171,25 @@ describe('Semantic validation', function () {
         ]);
     });
 });
+
+describe('Semantic validation of examples being edited', function () {
+    describe('deleting input identifier', function () {
+        let input = "input a\ninput\ninput a\n";
+        parseAndCheckErrors(input, [
+            new parserFacade.Error(2, 2, 5, 6, "missing ID at '\\n'"),
+            new parserFacade.Error(3, 3, 7, 8, "input already declared")
+        ]);
+    });
+    describe('deleting calculation value still declares the target', function () {
+        let input = "a = 1 + 1\nb = \nc = a + b\n";
+        parseAndCheckErrors(input, [
+            new parserFacade.Error(2, 2, 4, 5, "mismatched input '\\n' expecting {NUMBER_LIT, ID, '(', '-'}"),
+        ]);
+    });
+    describe('deleting output identifier', function () {
+        let input = "input a\noutput\noutput a\n";
+        parseAndCheckErrors(input, [
+            new parserFacade.Error(2, 2, 6, 7, "missing ID at '\\n'"),
+        ]);
+    });
+});


### PR DESCRIPTION
Inspired by issue #1, this PR implements semantic validation for identifiers in the calc language.

Following the rules of most mainstream programming languages, identifiers need to be declared before usage, and cannot be declared multiple times.

In the case of calc, the editor will report errors when:
* More than one `input` statements declare the same identifier
    ![inputs]   
* An identifier used in a `calculation` expression has not been declared in previous lines
    ![calculations]
* An identifier used in an `output` statement has not been declared in previous lines
    ![outputs]

Instead of an ANTLR listener or visitor, a simple parse tree walker is used to check the relevant nodes.  
Additional validation tests have been added  to the parsingTest file.
The features of  the editor are now documented in the readme.

[inputs]: https://github.com/Strumenta/calc-monaco-editor/assets/6147446/a9e85a3b-275b-4c4c-8c8b-be196016eba5
[calculations]: https://github.com/Strumenta/calc-monaco-editor/assets/6147446/ee744267-64c4-4da5-8e72-3399ba1cdd1c
[outputs]: https://github.com/Strumenta/calc-monaco-editor/assets/6147446/5d77874c-ebb1-4c10-ad04-7ff20900bbdd